### PR TITLE
Fixed memory leaks and analyzer warnings.

### DIFF
--- a/CodeaTemplate/CodeaTemplate/CodifyAppDelegate.m
+++ b/CodeaTemplate/CodeaTemplate/CodifyAppDelegate.m
@@ -83,7 +83,7 @@
     }
     
         
-    self.currentProject = [[Project alloc] initWithPath:destPath validFileTypes:[NSArray arrayWithObjects:@"lua", @"plist", nil]];
+    self.currentProject = [[[Project alloc] initWithPath:destPath validFileTypes:[NSArray arrayWithObjects:@"lua", @"plist", nil]] autorelease];
     [self showRenderView:YES animated:NO];
     [[CodifyScriptExecute sharedInstance] runProject:self.currentProject];
     

--- a/CodeaTemplate/Codify/BasicRendererViewController.mm
+++ b/CodeaTemplate/Codify/BasicRendererViewController.mm
@@ -102,6 +102,18 @@
 
 #pragma mark - Internal Initialization
 
+- (id) initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+	
+	if(self){
+		supportedOrientations = [[NSMutableSet alloc] initWithCapacity:4];
+		[self addSupportedOrientation:ORIENTATION_ANY];
+	}
+	
+	return self;
+}
+
 - (void) setup
 {
     self.showButtons = NO;
@@ -116,8 +128,6 @@
     
     renderManager = [[RenderManager alloc] init];
     physicsManager = [[PhysicsManager alloc] init];
-    supportedOrientations = [[NSMutableSet set] retain];
-    [self addSupportedOrientation:ORIENTATION_ANY];
     
     if (!aContext)
         NSLog(@"Failed to create ES context");
@@ -478,9 +488,7 @@
 #pragma mark - View preparation
 
 - (void) prepareViewForDisplay
-{    
-    [self addSupportedOrientation:ORIENTATION_ANY];     
-    
+{
     //Do some basic GL setup    
     [self startAnimation];           
     [self initialDrawSetup];          
@@ -1138,7 +1146,7 @@
             [supportedOrientations addObject:[NSNumber numberWithUnsignedInteger:UIInterfaceOrientationLandscapeRight]];                                                
             [supportedOrientations addObject:[NSNumber numberWithUnsignedInteger:UIInterfaceOrientationPortrait]];            
             [supportedOrientations addObject:[NSNumber numberWithUnsignedInteger:UIInterfaceOrientationPortraitUpsideDown]];                                    
-            break;       
+            break;
             
         default: //Default to landscape left and right
             [supportedOrientations addObject:[NSNumber numberWithUnsignedInteger:UIInterfaceOrientationLandscapeLeft]];                                    

--- a/CodeaTemplate/Codify/CodifyScriptExecute.m
+++ b/CodeaTemplate/Codify/CodifyScriptExecute.m
@@ -36,7 +36,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(CodifyScriptExecute);
     self = [super init];
     if( self )
     {
-        preloadScripts = [[NSMutableArray array] retain];
+        preloadScripts = [[NSMutableArray alloc] initWithCapacity:31];
         
         /*
         //Lua Socket        
@@ -51,8 +51,8 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(CodifyScriptExecute);
         */
         
         //Pre-load classes and sandbox lua files
-        [preloadScripts addObject:[SCRIPT_STRING("LuaSandbox") retain]];             
-        [preloadScripts addObject:[SCRIPT_STRING("Class") retain]];             
+        [preloadScripts addObject:SCRIPT_STRING("LuaSandbox")];
+        [preloadScripts addObject:SCRIPT_STRING("Class")];
         //luaSandbox = [[NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"LuaSandbox" ofType:@"lua"] usedEncoding:NULL error:NULL] retain];
         //luaClasses = [[NSString stringWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"Class" ofType:@"lua"] usedEncoding:NULL error:NULL] retain];        
         
@@ -105,7 +105,7 @@ SYNTHESIZE_SINGLETON_FOR_CLASS(CodifyScriptExecute);
         //Check here because the open source EditorBuffer doesnt have this message
         if ([buffer respondsToSelector:@selector(clearErrorMessage)])
         {
-            [buffer clearErrorMessages];
+            [buffer performSelector:@selector(clearErrorMessage)];
         }
         
         //Attempt to load this buffer into the Lua state

--- a/CodeaTemplate/Codify/Persistence.m
+++ b/CodeaTemplate/Codify/Persistence.m
@@ -428,6 +428,7 @@ UIImage* createUIImageFromImage(image_type* image)
     
     CGDataProviderRelease(provider);
     CGImageRelease(imageRef);
+	CGColorSpaceRelease(colorSpaceRef);
     
     return newImage;    
 }


### PR DESCRIPTION
CodifyAppDelegate
- Fixed memory leak by autoreleasing "Project" where the retained property "self.currentProject" was being assigned a retained "Project" in "- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions"

BasicRendererViewController
- Fixed runtime warning about returning NO to all supported orientations by setting up the supported orientations in the init method instead of the setup method
- Removed superfluous call to add SupportedOrientations from prepareViewForDisplay

CodifyScriptExecute
- init preloadScripts to an array with a capacity rather than using an autoreleased object
- Fixed memory leak by removing "retain" from adding objects to the preloadScripts array (the array will retain objects added and release when removed internally)
- Fixed warning about unknown selector "clearErrorMessage" by using performSelector: instead of just calling the selector directly

Persistence
- Fixed memory leak in createUIImageFromImage() by releasing the colorSpaceRef
